### PR TITLE
Include alloca.h on Solaris and Linux platforms.

### DIFF
--- a/src/physfs_internal.h
+++ b/src/physfs_internal.h
@@ -38,7 +38,7 @@
 #include <malloc.h>
 #endif
 
-#ifdef PHYSFS_PLATFORM_SOLARIS
+#if defined(PHYSFS_PLATFORM_SOLARIS) || defined(PHYSFS_PLATFORM_LINUX)
 #include <alloca.h>
 #endif
 


### PR DESCRIPTION
On Ubuntu 18.04 compiling with GCC 9 or Clang 9 I was receiving the following compiler error:
```
undefined reference to `alloca'
```

Original mailing list thread: http://icculus.org/pipermail/physfs/2020-April/001293.html