### PR TITLE
Add support for mount priority

### DIFF
--- a/src/physfs.c
+++ b/src/physfs.c
@@ -48,6 +48,7 @@ typedef struct __PHYSFS_DIRHANDLE__
     size_t rootlen;  /* subdirectory of archiver to use as root of archive (NULL for actual root) */
     const PHYSFS_Archiver *funcs;  /* Ptr to archiver info for this handle. */
     struct __PHYSFS_DIRHANDLE__ *next;  /* linked list stuff. */
+    int priority;
 } DirHandle;
 
 
@@ -1749,7 +1750,7 @@ int PHYSFS_setRoot(const char *archive, const char *subdir)
 
 
 static int doMount(PHYSFS_Io *io, const char *fname,
-                   const char *mountPoint, int appendToPath)
+                   const char *mountPoint, int priority)
 {
     DirHandle *dh;
     DirHandle *prev = NULL;
@@ -1767,23 +1768,24 @@ static int doMount(PHYSFS_Io *io, const char *fname,
         /* already in search path? */
         if ((i->dirName != NULL) && (strcmp(fname, i->dirName) == 0))
             BAIL_MUTEX_ERRPASS(stateLock, 1);
-        prev = i;
+        if ((priority < 0) || ((priority > 0) && (i->priority <= priority)))
+            prev = i;
     } /* for */
 
     dh = createDirHandle(io, fname, mountPoint, 0);
     BAIL_IF_MUTEX_ERRPASS(!dh, stateLock, 0);
 
-    if (appendToPath)
-    {
-        if (prev == NULL)
-            searchPath = dh;
-        else
-            prev->next = dh;
-    } /* if */
-    else
+    dh->priority = priority;
+
+    if (prev == NULL)
     {
         dh->next = searchPath;
         searchPath = dh;
+    } /* if */
+    else
+    {
+        dh->next = prev->next;
+        prev->next = dh;
     } /* else */
 
     __PHYSFS_platformReleaseMutex(stateLock);
@@ -1792,18 +1794,18 @@ static int doMount(PHYSFS_Io *io, const char *fname,
 
 
 int PHYSFS_mountIo(PHYSFS_Io *io, const char *fname,
-                   const char *mountPoint, int appendToPath)
+                   const char *mountPoint, int priority)
 {
     BAIL_IF(!io, PHYSFS_ERR_INVALID_ARGUMENT, 0);
     BAIL_IF(!fname, PHYSFS_ERR_INVALID_ARGUMENT, 0);
     BAIL_IF(io->version != 0, PHYSFS_ERR_UNSUPPORTED, 0);
-    return doMount(io, fname, mountPoint, appendToPath);
+    return doMount(io, fname, mountPoint, priority);
 } /* PHYSFS_mountIo */
 
 
 int PHYSFS_mountMemory(const void *buf, PHYSFS_uint64 len, void (*del)(void *),
                        const char *fname, const char *mountPoint,
-                       int appendToPath)
+                       int priority)
 {
     int retval = 0;
     PHYSFS_Io *io = NULL;
@@ -1813,7 +1815,7 @@ int PHYSFS_mountMemory(const void *buf, PHYSFS_uint64 len, void (*del)(void *),
 
     io = __PHYSFS_createMemoryIo(buf, len, del);
     BAIL_IF_ERRPASS(!io, 0);
-    retval = doMount(io, fname, mountPoint, appendToPath);
+    retval = doMount(io, fname, mountPoint, priority);
     if (!retval)
     {
         /* docs say not to call (del) in case of failure, so cheat. */
@@ -1827,7 +1829,7 @@ int PHYSFS_mountMemory(const void *buf, PHYSFS_uint64 len, void (*del)(void *),
 
 
 int PHYSFS_mountHandle(PHYSFS_File *file, const char *fname,
-                       const char *mountPoint, int appendToPath)
+                       const char *mountPoint, int priority)
 {
     int retval = 0;
     PHYSFS_Io *io = NULL;
@@ -1837,7 +1839,7 @@ int PHYSFS_mountHandle(PHYSFS_File *file, const char *fname,
 
     io = __PHYSFS_createHandleIo(file);
     BAIL_IF_ERRPASS(!io, 0);
-    retval = doMount(io, fname, mountPoint, appendToPath);
+    retval = doMount(io, fname, mountPoint, priority);
     if (!retval)
     {
         /* docs say not to destruct in case of failure, so cheat. */
@@ -1849,16 +1851,16 @@ int PHYSFS_mountHandle(PHYSFS_File *file, const char *fname,
 } /* PHYSFS_mountHandle */
 
 
-int PHYSFS_mount(const char *newDir, const char *mountPoint, int appendToPath)
+int PHYSFS_mount(const char *newDir, const char *mountPoint, int priority)
 {
     BAIL_IF(!newDir, PHYSFS_ERR_INVALID_ARGUMENT, 0);
-    return doMount(NULL, newDir, mountPoint, appendToPath);
+    return doMount(NULL, newDir, mountPoint, priority);
 } /* PHYSFS_mount */
 
 
 int PHYSFS_addToSearchPath(const char *newDir, int appendToPath)
 {
-    return PHYSFS_mount(newDir, NULL, appendToPath);
+    return PHYSFS_mount(newDir, NULL, appendToPath ? -1 : 0);
 } /* PHYSFS_addToSearchPath */
 
 

--- a/src/physfs.h
+++ b/src/physfs.h
@@ -2184,7 +2184,7 @@ PHYSFS_DECL int PHYSFS_setAllocator(const PHYSFS_Allocator *allocator);
 
 
 /**
- * \fn int PHYSFS_mount(const char *newDir, const char *mountPoint, int appendToPath)
+ * \fn int PHYSFS_mount(const char *newDir, const char *mountPoint, int priority)
  * \brief Add an archive or directory to the search path.
  *
  * If this is a duplicate, the entry is not added again, even though the
@@ -2218,7 +2218,8 @@ PHYSFS_DECL int PHYSFS_setAllocator(const PHYSFS_Allocator *allocator);
  *   \param mountPoint Location in the interpolated tree that this archive
  *                     will be "mounted", in platform-independent notation.
  *                     NULL or "" is equivalent to "/".
- *   \param appendToPath nonzero to append to search path, zero to prepend.
+ *   \param priority Archive priority.  Positive inserts archive AFTER others
+ *                   with the same priority; negative appends, zero prepends.
  *  \return nonzero if added to path, zero on failure (bogus archive, dir
  *          missing, etc). Use PHYSFS_getLastErrorCode() to obtain
  *          the specific error.
@@ -2230,7 +2231,7 @@ PHYSFS_DECL int PHYSFS_setAllocator(const PHYSFS_Allocator *allocator);
  */
 PHYSFS_DECL int PHYSFS_mount(const char *newDir,
                              const char *mountPoint,
-                             int appendToPath);
+                             int priority);
 
 /**
  * \fn int PHYSFS_getMountPoint(const char *dir)
@@ -3226,7 +3227,7 @@ typedef struct PHYSFS_Io
 
 
 /**
- * \fn int PHYSFS_mountIo(PHYSFS_Io *io, const char *newDir, const char *mountPoint, int appendToPath)
+ * \fn int PHYSFS_mountIo(PHYSFS_Io *io, const char *newDir, const char *mountPoint, int priority)
  * \brief Add an archive, built on a PHYSFS_Io, to the search path.
  *
  * \warning Unless you have some special, low-level need, you should be using
@@ -3256,7 +3257,7 @@ typedef struct PHYSFS_Io
  *   \param mountPoint Location in the interpolated tree that this archive
  *                     will be "mounted", in platform-independent notation.
  *                     NULL or "" is equivalent to "/".
- *   \param appendToPath nonzero to append to search path, zero to prepend.
+ *   \param priority Archive priority; see PHYSFS_mount.
  *  \return nonzero if added to path, zero on failure (bogus archive, stream
  *                   i/o issue, etc). Use PHYSFS_getLastErrorCode() to obtain
  *                   the specific error.
@@ -3266,11 +3267,11 @@ typedef struct PHYSFS_Io
  * \sa PHYSFS_getMountPoint
  */
 PHYSFS_DECL int PHYSFS_mountIo(PHYSFS_Io *io, const char *newDir,
-                               const char *mountPoint, int appendToPath);
+                               const char *mountPoint, int priority);
 
 
 /**
- * \fn int PHYSFS_mountMemory(const void *buf, PHYSFS_uint64 len, void (*del)(void *), const char *newDir, const char *mountPoint, int appendToPath)
+ * \fn int PHYSFS_mountMemory(const void *buf, PHYSFS_uint64 len, void (*del)(void *), const char *newDir, const char *mountPoint, int priority)
  * \brief Add an archive, contained in a memory buffer, to the search path.
  *
  * \warning Unless you have some special, low-level need, you should be using
@@ -3304,7 +3305,7 @@ PHYSFS_DECL int PHYSFS_mountIo(PHYSFS_Io *io, const char *newDir,
  *   \param mountPoint Location in the interpolated tree that this archive
  *                     will be "mounted", in platform-independent notation.
  *                     NULL or "" is equivalent to "/".
- *   \param appendToPath nonzero to append to search path, zero to prepend.
+ *   \param priority Archive priority; see PHYSFS_mount.
  *  \return nonzero if added to path, zero on failure (bogus archive, etc).
  *          Use PHYSFS_getLastErrorCode() to obtain the specific error.
  *
@@ -3314,11 +3315,11 @@ PHYSFS_DECL int PHYSFS_mountIo(PHYSFS_Io *io, const char *newDir,
  */
 PHYSFS_DECL int PHYSFS_mountMemory(const void *buf, PHYSFS_uint64 len,
                                    void (*del)(void *), const char *newDir,
-                                   const char *mountPoint, int appendToPath);
+                                   const char *mountPoint, int priority);
 
 
 /**
- * \fn int PHYSFS_mountHandle(PHYSFS_File *file, const char *newDir, const char *mountPoint, int appendToPath)
+ * \fn int PHYSFS_mountHandle(PHYSFS_File *file, const char *newDir, const char *mountPoint, int priority)
  * \brief Add an archive, contained in a PHYSFS_File handle, to the search path.
  *
  * \warning Unless you have some special, low-level need, you should be using
@@ -3362,7 +3363,7 @@ PHYSFS_DECL int PHYSFS_mountMemory(const void *buf, PHYSFS_uint64 len,
  *   \param mountPoint Location in the interpolated tree that this archive
  *                     will be "mounted", in platform-independent notation.
  *                     NULL or "" is equivalent to "/".
- *   \param appendToPath nonzero to append to search path, zero to prepend.
+ *   \param priority Archive priority; see PHYSFS_mount.
  *  \return nonzero if added to path, zero on failure (bogus archive, etc).
  *          Use PHYSFS_getLastErrorCode() to obtain the specific error.
  *
@@ -3371,7 +3372,7 @@ PHYSFS_DECL int PHYSFS_mountMemory(const void *buf, PHYSFS_uint64 len,
  * \sa PHYSFS_getMountPoint
  */
 PHYSFS_DECL int PHYSFS_mountHandle(PHYSFS_File *file, const char *newDir,
-                                   const char *mountPoint, int appendToPath);
+                                   const char *mountPoint, int priority);
 
 
 /**


### PR DESCRIPTION
This allows limited manipulation of the search path without unmounting/remounting to get mounts in the right order.

It makes negligible changes to the API, repurposing the existing "appendToPath" parameter to `PHYSFS_mount*` and handling typical "flag" values (0, 1, -1) in such a way that current programs should have no change in function.  An int is added to each `DirHandle` to store the mount's priority for later comparison.

I had a use case in mind when I initially wrote this, but the specifics are lost to memory (that was almost 3 years ago).  Something that comes to mind is dynamically mounted DLC and UGC:  one might mount UGC at a high priority (say 5), so that it overrides DLC at priority 10, which in turn overrides base content at priority 20.  If a new DLC package is mounted mid-game, also at priority 10, it won't inadvertently override mounted UGC.