### PR TITLE
Use the GNUInstallDirs CMake module to respect installation locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ cmake_minimum_required(VERSION 2.8.12)
 project(PhysicsFS)
 set(PHYSFS_VERSION 3.1.0)
 
+include(GNUInstallDirs)
+
 # Increment this if/when we break backwards compatibility.
 set(PHYSFS_SOVERSION 1)
 
@@ -215,14 +217,14 @@ if(PHYSFS_BUILD_TEST)
 endif()
 
 install(TARGETS ${PHYSFS_INSTALL_TARGETS} EXPORT PhysFSExport
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib${LIB_SUFFIX}
-        ARCHIVE DESTINATION lib${LIB_SUFFIX}
-        INCLUDES DESTINATION include)
-install(FILES src/physfs.h DESTINATION include)
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES src/physfs.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 install(EXPORT PhysFSExport
-        DESTINATION "lib${LIB_SUFFIX}/cmake/PhysFS"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/PhysFS"
         FILE PhysFSConfig.cmake
 )
 
@@ -279,7 +281,7 @@ if(NOT MSVC)
     )
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/extras/physfs.pc"
-        DESTINATION "lib${LIB_SUFFIX}/pkgconfig"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
     )
 endif()
 
@@ -310,4 +312,3 @@ if(PHYSFS_BUILD_TEST)
 endif()
 
 # end of CMakeLists.txt ...
-

--- a/extras/physfs.pc.in
+++ b/extras/physfs.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
-includedir=${prefix}/include
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: PhysicsFS
 Description: PhysicsFS is a library to provide abstract access to various archives.


### PR DESCRIPTION
Apparently use of `LIB_SUFFIX` is now discouraged. `GNUInstallDirs` does a better job of setting a default.

The `libdir` of `${prefix}/lib` in the pkg-config file caused warnings, and possibly even failures, when linking on multilib systems where `/usr/lib` is for 32-bit libraries rather than 64-bit libraries.