### PR TITLE
Fix UTF-16 to UTF-8 conversion

### DIFF
--- a/src/physfs_unicode.c
+++ b/src/physfs_unicode.c
@@ -210,7 +210,7 @@ static PHYSFS_uint32 utf16codepoint(const PHYSFS_uint16 **_str)
         else
         {
             src++;  /* eat the other surrogate. */
-            cp = (0x10000 | ((cp - 0xD800) << 10) | (pair - 0xDC00));
+            cp = 0x10000 + (((cp - 0xD800) << 10) | (pair - 0xDC00));
         } /* else */
     } /* else if */
 

--- a/src/physfs_unicode.c
+++ b/src/physfs_unicode.c
@@ -210,7 +210,7 @@ static PHYSFS_uint32 utf16codepoint(const PHYSFS_uint16 **_str)
         else
         {
             src++;  /* eat the other surrogate. */
-            cp = (((cp - 0xD800) << 10) | (pair - 0xDC00));
+            cp = (0x10000 | ((cp - 0xD800) << 10) | (pair - 0xDC00));
         } /* else */
     } /* else if */
 


### PR DESCRIPTION
Converting UTF-16 surrogate pairs to temporary UTF-32 codepoints is missing the 0x10000 bit, which causes failure when enumerating directories containing particular unicode filenames on Windows.