### PR TITLE
disable dllexport from static builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,10 @@ if(PHYSFS_BUILD_STATIC)
 		set_target_properties(physfs-static PROPERTIES VS_WINRT_COMPONENT True)
         set_target_properties(physfs-static PROPERTIES STATIC_LIBRARY_FLAGS "/ignore:4264")
     endif()
+    if(WIN32 OR WINRT OR OS2)
+        # no dll exports from the static library
+        set_target_properties(physfs-static PROPERTIES DEFINE_SYMBOL PHYSFS_STATIC)
+    endif()
 
     set(PHYSFS_LIB_TARGET physfs-static)
     set(PHYSFS_INSTALL_TARGETS ${PHYSFS_INSTALL_TARGETS} ";physfs-static")

--- a/src/physfs.h
+++ b/src/physfs.h
@@ -225,6 +225,8 @@ extern "C" {
 
 #if defined(PHYSFS_DECL)
 /* do nothing. */
+#elif defined(PHYSFS_STATIC)
+#define PHYSFS_DECL   /**/
 #elif defined(_WIN32) || defined(__OS2__)
 #define PHYSFS_DECL __declspec(dllexport)
 #elif defined(__SUNPRO_C)


### PR DESCRIPTION
I think this is also a better solution than PR/15, so:
Closes: https://github.com/icculus/physfs/pull/15