### PR TITLE
cmake: explicitly link to advapi32 and shell32

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       if: contains(matrix.platform.name, 'MinGW')
       run:  choco install ninja
     - name: Get PhysicsFS sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Configure CMake
       run: cmake -B build ${{ matrix.platform.flags }}
     - name: Build

--- a/.github/workflows/os2.yml
+++ b/.github/workflows/os2.yml
@@ -6,7 +6,7 @@ jobs:
   os2:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: open-watcom/setup-watcom@v0
       - name: Build physfs.dll
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ set(PHYSFS_M_SRCS)
 set(PHYSFS_CPP_SRCS)
 
 # I hate that they define "WIN32" ... we're about to move to Win64...I hope!
+if(WIN32)
+    list(APPEND OPTIONAL_LIBRARY_LIBS advapi32 shell32)
+endif()
 
 if(APPLE)
     set(OTHER_LDFLAGS ${OTHER_LDFLAGS} "-framework IOKit -framework Foundation")
@@ -61,7 +64,7 @@ endif()
 if(UNIX AND NOT WIN32 AND NOT APPLE)  # (MingW and such might be UNIX _and_ WINDOWS!)
     find_library(PTHREAD_LIBRARY pthread)
     if(PTHREAD_LIBRARY)
-        set(OPTIONAL_LIBRARY_LIBS ${OPTIONAL_LIBRARY_LIBS} ${PTHREAD_LIBRARY})
+        list(APPEND OPTIONAL_LIBRARY_LIBS ${PTHREAD_LIBRARY})
     endif()
 endif()
 
@@ -191,7 +194,7 @@ if(PHYSFS_BUILD_SHARED)
     set_target_properties(physfs PROPERTIES SOVERSION ${PHYSFS_SOVERSION})
     set_target_properties(physfs PROPERTIES EXPORT_NAME PhysFS)
     if(WINRT)
-		set_target_properties(physfs PROPERTIES VS_WINRT_COMPONENT True)
+		set_target_properties(physfs PROPERTIES VS_WINRT_COMPONENT TRUE)
     endif()
     if(OS2) # OS/2 does not support a DLL name longer than 8 characters.
         set_target_properties(physfs PROPERTIES OUTPUT_NAME "physfs")


### PR DESCRIPTION
This fixes unresolved external symbols when building physfs for ARM:
```
     Creating library D:/a/physfs/physfs/build/Debug/physfs.lib and object D:/a/physfs/physfs/build/Debug/physfs.exp
physfs_platform_windows.obj : error LNK2019: unresolved external symbol __imp_OpenProcessToken referenced in function __PHYSFS_platformCalcUserDir [D:\a\physfs\physfs\build\physfs.vcxproj]
physfs_platform_windows.obj : error LNK2019: unresolved external symbol __imp_SHGetFolderPathW referenced in function __PHYSFS_platformCalcPrefDir [D:\a\physfs\physfs\build\physfs.vcxproj]
D:\a\physfs\physfs\build\Debug\physfs.dll : fatal error LNK1120: 2 unresolved externals [D:\a\physfs\physfs\build\physfs.vcxproj]
```

Also bump the `actions/checkout` action to fix node deprecation warnings.