### PR TITLE
physfs_platform_windows.c: Only compile with CreateFile2 support for WinRT

### DIFF
--- a/src/physfs_platform_windows.c
+++ b/src/physfs_platform_windows.c
@@ -123,7 +123,7 @@ static inline HANDLE winCreateFileW(const WCHAR *wfname, const DWORD mode,
                                     const DWORD creation)
 {
     const DWORD share = FILE_SHARE_READ | FILE_SHARE_WRITE;
-    #if defined(PHYSFS_PLATFORM_WINRT) || (_WIN32_WINNT >= 0x0602) // Windows 8+
+    #if defined(PHYSFS_PLATFORM_WINRT) // also available if targeting Windows 8+ || (_WIN32_WINNT >= 0x0602) - but do not include this for now, due to common toolchain defaults
     return CreateFile2(wfname, mode, share, creation, NULL);
     #else
     return CreateFileW(wfname, mode, share, NULL, creation,


### PR DESCRIPTION
To avoid a commonly-hit issue due to toolchain / project defaults.

See comments of #7