### PR TITLE
physfssdl3.c: add call to SDL_INIT_INTERFACE in create_iostream

### DIFF
--- a/extras/physfssdl3.c
+++ b/extras/physfssdl3.c
@@ -115,6 +115,7 @@ static SDL_IOStream *create_iostream(PHYSFS_File *handle)
         SDL_SetError("PhysicsFS error: %s", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
     } else {
         SDL_IOStreamInterface iface;
+        SDL_INIT_INTERFACE(&iface);
         iface.size  = physfsiostream_size;
         iface.seek  = physfsiostream_seek;
         iface.read  = physfsiostream_read;


### PR DESCRIPTION
Hello!

I had some problems calling `PHYSFSSDL3_openRead()`: `Invalid interface, should be initialized with SDL_INIT_INTERFACE()`.

If I'm not mistaken, a call to `SDL_INIT_INTERFACE()` is needed when using a `SDL_IOStreamInterface` structure, this is what this PR adds.

Have a good day!