### PR TITLE
physfssdl3.c: add call to SDL_INIT_INTERFACE in PHYSFSSDL3_makeStorage

### DIFF
--- a/extras/physfssdl3.c
+++ b/extras/physfssdl3.c
@@ -283,6 +283,7 @@ static Uint64 SDLCALL physfssdl3storage_space_remaining(void *userdata)
 SDL_Storage *PHYSFSSDL3_makeStorage(void)
 {
     SDL_StorageInterface iface;
+    SDL_INIT_INTERFACE(&iface);
     iface.close = physfssdl3storage_close;
     iface.ready = physfssdl3storage_ready;
     iface.enumerate = physfssdl3storage_enumerate;


### PR DESCRIPTION
Add missing `SDL_INIT_INTERFACE` to `PHYSFSSDL3_makeStorage`. It was triggering the following error in SDL3

```
Invalid interface, should be initialized with SDL_INIT_INTERFACE()
```