### PR TITLE
cmake: bump minimum cmake version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 
 set(PHYSFS_VERSION 3.3.0)
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(PhysicsFS VERSION ${PHYSFS_VERSION} LANGUAGES C )
 


### PR DESCRIPTION
This pull request gets rid of this warning:
```
CMake Deprecation Warning at CMakeLists.txt:14 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```

It is also worth noting that the project does not build on the latest release tag `release-3.2.0` on the latest release of CMake, since version 4.0 drops compatibility with CMake < 3.5 completely (mentioned in issue #96).