### PR TITLE
libretro: Minor mutex fix

### DIFF
--- a/src/physfs_platform_libretro.c
+++ b/src/physfs_platform_libretro.c
@@ -208,7 +208,7 @@ void __PHYSFS_platformDestroyMutex(void *mutex)
 int __PHYSFS_platformGrabMutex(void *mutex)
 {
 #ifdef PHYSFS_PLATFORM_LIBRETRO_NO_THREADS
-    return 0;
+    return 1; /* Single-threaded, so we ignore this by returning success. */
 #else
     PthreadMutex *m = (PthreadMutex *) mutex;
     uintptr_t tid = sthread_get_current_thread_id();


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the PhysicsFS project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

This is a minor change to return a 1 on `grabMutex` when on a single-threaded application. This mimics the same behavior across other platforms, like playdate.
