### PR TITLE
Fix -Wdiscarded-qualifiers warning

### DIFF
--- a/src/physfs.c
+++ b/src/physfs.c
@@ -1106,7 +1106,7 @@ static char *calculateBaseDir(const char *argv0)
 {
     const char dirsep = __PHYSFS_platformDirSeparator;
     char *retval = NULL;
-    char *ptr = NULL;
+    const char *ptr = NULL;
 
     /* Give the platform layer first shot at this. */
     retval = __PHYSFS_platformCalcBaseDir(argv0);


### PR DESCRIPTION
src/physfs.c:1119:9: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 1119 |     ptr = strrchr(argv0, dirsep);
      |         ^

- [x] I confirm that I am the author of this code and release it to the PhysicsFS project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

