### PR TITLE
Remove references to MWERKS of classic MacOS

### DIFF
--- a/src/physfs_internal.h
+++ b/src/physfs_internal.h
@@ -55,8 +55,6 @@ extern "C" {
 
 #ifdef __cplusplus
     /* C++ always has a real inline keyword. */
-#elif (defined macintosh) && !(defined __MWERKS__)
-#   define inline
 #elif (defined _MSC_VER)
 #   define inline __inline
 #endif

--- a/test/test_physfs.c
+++ b/test/test_physfs.c
@@ -13,10 +13,6 @@
 #include <errno.h>
 #include <string.h>
 
-#if (defined __MWERKS__)
-#include <SIOUX.h>
-#endif
-
 #if (defined PHYSFS_HAVE_READLINE)
 #include <unistd.h>
 #include <readline/readline.h>
@@ -1658,14 +1654,6 @@ int main(int argc, char **argv)
     char *buf = NULL;
     int rc = 1;
     int i;
-
-#if (defined __MWERKS__)
-    extern tSIOUXSettings SIOUXSettings;
-    SIOUXSettings.asktosaveonclose = 0;
-    SIOUXSettings.autocloseonquit = 1;
-    SIOUXSettings.rows = 40;
-    SIOUXSettings.columns = 120;
-#endif
 
     printf("\n");
 


### PR DESCRIPTION
Fixes #118

- [x] I confirm that I am the author of this code and release it to the PhysicsFS project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

