### PR TITLE
Avoid writing into freed memory when creating prefDir fails

### DIFF
--- a/src/physfs.c
+++ b/src/physfs.c
@@ -1696,6 +1696,7 @@ const char *PHYSFS_getPrefDir(const char *org, const char *app)
         {
             allocator.Free(prefDir);
             prefDir = NULL;
+            return NULL;  /* endstr points into the freed buffer. */
         } /* if */
     } /* if */
 


### PR DESCRIPTION
- [ ] I confirm that I am the author of this code and release it to the PhysicsFS project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Actually I ran into this problem while using AI and it told me this line was necessary, so I can hardly check the above box. However, I verified the issue by tracing the code myself and I don't believe this particular fix would be problematic due to any conflicting license terms.

The AI was trying to check the behavior under an isolated HOME, and wrote an env setup with an empty `XDG_DATA_HOME` rather than unsetting it. This triggered a core dump. The same issue can happen when there are permission issues with creating the directory, for example.